### PR TITLE
Continue error resolution

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -689,14 +689,16 @@
     function setSpeed(val){
       if (!intervals[currentIntervalIndex]) return;
       intervals[currentIntervalIndex].speed_mph = Math.max(0, Number(val));
-      $('#speedValue').textContent = intervals[currentIntervalIndex].speed_mph.toFixed(1) + ' mph';
+      const speedEl = $('#speedValue');
+      if (speedEl) speedEl.textContent = intervals[currentIntervalIndex].speed_mph.toFixed(1) + ' mph';
       $('#current-speed').textContent = intervals[currentIntervalIndex].speed_mph.toFixed(1);
       updateSummary(); updateProgressUI(); if (typeof saveLastSession === 'function') saveLastSession();
     }
     function setIncline(val){
       if (!intervals[currentIntervalIndex]) return;
       intervals[currentIntervalIndex].incline = Math.min(40, Math.max(0, Number(val)));
-      $('#inclineValue').textContent = intervals[currentIntervalIndex].incline.toFixed(1) + '%';
+      const inclineEl = $('#inclineValue');
+      if (inclineEl) inclineEl.textContent = intervals[currentIntervalIndex].incline.toFixed(1) + '%';
       $('#current-incline').textContent = intervals[currentIntervalIndex].incline.toFixed(1);
       updateSummary(); updateProgressUI(); if (typeof saveLastSession === 'function') saveLastSession();
     }
@@ -969,8 +971,10 @@
       setPhaseBackground(phase);
 
       // Reflect current speed/incline in quick controls
-      $('#speedValue').textContent = (current.speed_mph ?? 0).toFixed(1) + ' mph';
-      $('#inclineValue').textContent = (current.incline || 0).toFixed(1) + '%';
+      const speedEl = $('#speedValue');
+      if (speedEl) speedEl.textContent = (current.speed_mph ?? 0).toFixed(1) + ' mph';
+      const inclineEl = $('#inclineValue');
+      if (inclineEl) inclineEl.textContent = (current.incline || 0).toFixed(1) + '%';
 
       // Voice announce current interval
       speak(`${current.section || 'Interval'}: ${current.duration_min} minutes at ${(current.speed_mph ?? 0).toFixed(1)} miles per hour${current.incline? ', incline ' + Number(current.incline).toFixed(1) + ' percent' : ''}`);


### PR DESCRIPTION
Add defensive checks for `#speedValue` and `#inclineValue` elements to prevent null reference errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dcba633-5323-4c4b-af95-de7ea7791492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0dcba633-5323-4c4b-af95-de7ea7791492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

